### PR TITLE
add PositionalParanamer which can be used as last fallback of AdaptiveParanamer and produces parameters names like arg0, arg1, ...

### DIFF
--- a/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
@@ -1,0 +1,85 @@
+/**
+ *
+ * Copyright (c) 2013 Stefan Fleiter
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.thoughtworks.paranamer;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * Paranamer that works on basis of the parameter position and can be used as
+ * last fallback of the <code>AdaptiveParanamer</code>.
+ * 
+ * @author Stefan Fleiter
+ */
+public class PositionalParanamer implements Paranamer {
+
+    private final String prefix;
+
+    /**
+     * Default Contstructor with prefix <code>arg</code>.
+     */
+    public PositionalParanamer() {
+        this("arg");
+    }
+
+    /**
+     * Constructor that allows to override the prefix.
+     * 
+     * @param prefix
+     *            string that is prepended before the position of the parameter.
+     */
+    public PositionalParanamer(String prefix) {
+        super();
+        this.prefix = prefix;
+    }
+
+    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
+        return lookupParameterNames(methodOrConstructor, true);
+    }
+
+    public String[] lookupParameterNames(AccessibleObject methodOrCtor,
+            boolean throwExceptionIfMissing) {
+        int count;
+        if (methodOrCtor instanceof Method) {
+            Method method = (Method) methodOrCtor;
+            count = method.getParameterTypes().length;
+        } else {
+            Constructor<?> constructor = (Constructor<?>) methodOrCtor;
+            count = constructor.getParameterTypes().length;
+        }
+        String[] result = new String[count];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = prefix + i;
+        }
+        return result;
+    }
+
+}

--- a/paranamer/src/test/com/thoughtworks/paranamer/PositionalParanamerTestCase.java
+++ b/paranamer/src/test/com/thoughtworks/paranamer/PositionalParanamerTestCase.java
@@ -1,0 +1,80 @@
+package com.thoughtworks.paranamer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PositionalParanamerTestCase {
+
+    Paranamer paranamer;
+
+    @Before
+    public void setUp() throws Exception {
+        paranamer = new PositionalParanamer();
+    }
+
+    @Test
+    public void testRetrievesParameterNamesFromAMethod()
+            throws SecurityException, NoSuchMethodException {
+        Method method = Clazz.class.getMethod("singleString",
+                new Class[] { String.class });
+        assertEquals("arg0", paranamer.lookupParameterNames(method)[0]);
+    }
+
+    @Test
+    public void testRetrievesParameterNamesFromAConstructor()
+            throws SecurityException, NoSuchMethodException {
+        Constructor<?> ctor = Clazz.class.getConstructor(String.class);
+        assertEquals("arg0", paranamer.lookupParameterNames(ctor)[0]);
+    }
+
+    @Test
+    public void testRetrievesParameterNamesFromAMethodWithoutParameters()
+            throws SecurityException, NoSuchMethodException {
+        Method method = Clazz.class.getMethod("noParameters", new Class[0]);
+        assertArrayEquals(new String[] {},
+                paranamer.lookupParameterNames(method));
+    }
+
+    @Test
+    public void testRetrievesParameterNamesFromMethodWithDoubleMixedInTheParameters()
+            throws SecurityException, NoSuchMethodException {
+        Method method = Clazz.class.getMethod("mixedParameters", new Class[] {
+                double.class, String.class });
+        assertArrayEquals(new String[] { "arg0", "arg1" },
+                paranamer.lookupParameterNames(method));
+    }
+
+    @Test
+    public void testRetrievesParameterNamesFromMethodWithDoubleMixedInTheParametersAndCustomPrefix()
+            throws SecurityException, NoSuchMethodException {
+        paranamer = new PositionalParanamer("foo");
+        Method method = Clazz.class.getMethod("mixedParameters", new Class[] {
+                double.class, String.class });
+        assertArrayEquals(new String[] { "foo0", "foo1" },
+                paranamer.lookupParameterNames(method));
+    }
+
+    public static class Clazz {
+        public Clazz(String foo) {
+        }
+
+        public void singleString(String s) {
+        }
+
+        public static void staticWithParameter(int i) {
+        }
+
+        public void noParameters() {
+        }
+
+        public void mixedParameters(double d, String s) {
+        }
+    }
+
+}


### PR DESCRIPTION
I'd like to use that paranamer as fallback if real parameter names can not be detected.
Since I assume others might want to use that to I hereby provide it.
I use paranamer in my project [sfleiter/cdi-interceptors](https://github.com/sfleiter/cdi-interceptors) for generic logging of method calls with paramaters, result, excception and duration.

I do not know whether the Copyright notice in PositionalParanamer.java is as expected, I simply adapted it from `BytecodeReadingParanamer`. If changes are needed there that would be no problem for me.
