### PR TITLE
Changing legacy maven properties

### DIFF
--- a/paranamer-ant/pom.xml
+++ b/paranamer-ant/pom.xml
@@ -10,9 +10,9 @@
   <description>ParaNamer Ant tasks</description>
   <dependencies>
     <dependency>
-      <groupId>${pom.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>paranamer-generator</artifactId>
-      <version>${pom.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>

--- a/paranamer-distribution/pom.xml
+++ b/paranamer-distribution/pom.xml
@@ -11,14 +11,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>${pom.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>paranamer-generator</artifactId>
-      <version>${pom.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${pom.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>paranamer-ant</artifactId>
-      <version>${pom.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -40,9 +40,9 @@
               <overWriteSnapshots>true</overWriteSnapshots>
               <artifactItems>
                 <artifactItem>
-                  <groupId>${pom.groupId}</groupId>
+                  <groupId>${project.groupId}</groupId>
                   <artifactId>paranamer</artifactId>
-                  <version>${pom.version}</version>
+                  <version>${project.version}</version>
                   <classifier>javadoc</classifier>
                 </artifactItem>
               </artifactItems>
@@ -112,7 +112,7 @@
             </goals>
             <configuration>
               <descriptor>${basedir}/src/assembly/assembly-bin.xml</descriptor>
-              <finalName>paranamer-${pom.version}</finalName>
+              <finalName>paranamer-${project.version}</finalName>
               <workDirectory>${project.build.directory}/assembly/bin</workDirectory>
             </configuration>
           </execution>
@@ -124,7 +124,7 @@
             </goals>
             <configuration>
               <descriptor>${basedir}/src/assembly/assembly-src.xml</descriptor>
-              <finalName>paranamer-${pom.version}</finalName>
+              <finalName>paranamer-${project.version}</finalName>
               <workDirectory>${project.build.directory}/assembly/src</workDirectory>
             </configuration>
           </execution>

--- a/paranamer-integration-tests/it-011/pom.xml
+++ b/paranamer-integration-tests/it-011/pom.xml
@@ -13,7 +13,7 @@
       <plugin>
         <groupId>com.thoughtworks.paranamer</groupId>
         <artifactId>paranamer-maven-plugin</artifactId>
-        <version>${pom.version}</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <goals>

--- a/paranamer-maven-plugin/pom.xml
+++ b/paranamer-maven-plugin/pom.xml
@@ -11,9 +11,9 @@
   <description>ParaNamer Maven plugin</description>
   <dependencies>
     <dependency>
-      <groupId>${pom.groupId}</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>paranamer-generator</artifactId>
-      <version>${pom.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -34,8 +34,8 @@
         <scope>test</scope>
     </dependency>
       <dependency>
-          <groupId>${groupId}</groupId>
-          <artifactId>${artifactId}</artifactId>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${project.artifactId}</artifactId>
           <version>2.5.5</version>
           <classifier>javadoc</classifier>
           <scope>test</scope>
@@ -70,6 +70,7 @@
       <plugin>
         <groupId>com.thoughtworks.paranamer</groupId>
         <artifactId>paranamer-maven-plugin</artifactId>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -79,8 +80,8 @@
           </execution>
         </executions>
         <configuration>
-          <sourceDirectory>${pom.build.sourceDirectory}</sourceDirectory>
-          <outputDirectory>${pom.build.outputDirectory}</outputDirectory>
+          <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
         </configuration>
       </plugin>
         <plugin>
@@ -96,8 +97,8 @@
                     <configuration>
                         <excludeTransitive>true</excludeTransitive>
                         <classifier>javadoc</classifier>
-                        <includeGroupIds>net.sourceforge.f2j,${groupId}</includeGroupIds>
-                        <includeArtifactIds>arpack_combined_all,${artifactId}</includeArtifactIds>
+                        <includeGroupIds>net.sourceforge.f2j,${project.groupId}</includeGroupIds>
+                        <includeArtifactIds>arpack_combined_all,${project.artifactId}</includeArtifactIds>
                         <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
                         <outputDirectory>${project.build.directory}/test-data</outputDirectory>
                     </configuration>


### PR DESCRIPTION
`Pom` property is deprecated, and `project` property is replacement. There are no problem yet to use `pom` property (only warns are printed in console), but may be in future versions of maven.
