### PR TITLE
Support -DskipParanamer On Command Line in Maven Plugin

### DIFF
--- a/paranamer-maven-plugin/src/java/com/thoughtworks/paranamer/mojo/ParanamerGeneratorMojo.java
+++ b/paranamer-maven-plugin/src/java/com/thoughtworks/paranamer/mojo/ParanamerGeneratorMojo.java
@@ -31,7 +31,6 @@
 package com.thoughtworks.paranamer.mojo;
 
 import java.io.IOException;
-import java.util.TreeSet;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;


### PR DESCRIPTION
Just a quickie. We use the plugin to generate some runtime data, but the code base is quite large and the paranamer plugin is intolerably slow for dev cycles.

Used like this:

`call mvn -DskipParanamer install`
