### PR TITLE
Include OSGi headers in the manifest.

### DIFF
--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -6,6 +6,7 @@
     <version>2.7-SNAPSHOT</version>
   </parent>
   <artifactId>paranamer</artifactId>
+  <packaging>bundle</packaging>
   <name>ParaNamer Core</name>
   <dependencies>
     <dependency>
@@ -105,6 +106,18 @@
                 </execution>
             </executions>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <configuration>
+            <instructions>
+              <Export-Package>com.thoughtworks.paranamer</Export-Package>
+            </instructions>
+          </configuration>
+        </plugin>
+        
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,14 @@
                         </execution>
                     </executions>
                 </plugin>
-            </plugins>
+
+                <plugin>
+                  <groupId>org.apache.felix</groupId>
+                  <artifactId>maven-bundle-plugin</artifactId>
+                  <version>2.3.7</version>
+                </plugin>
+
+              </plugins>
         </pluginManagement>
         
         <plugins>


### PR DESCRIPTION
This allows the JAR to be used in a OSGi container (such as Eclipse Virgo). The new headers should not impact non-OSGi usage in any way.
