### PR TITLE
Closes #17. Added constant pool tags to work with Java 8 Lambdas.

### DIFF
--- a/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
@@ -415,6 +415,16 @@ public class BytecodeReadingParanamer implements Paranamer {
         final static int NAME_TYPE = 12;
 
         /**
+        * The type of CONSTANT_MethodHandle constant pool items.
+        */
+        static final int MHANDLE = 15;
+
+        /**
+        * The type of CONSTANT_InvokeDynamic constant pool items.
+        */
+        static final int INVOKEDYN = 18;
+
+        /**
          * The type of CONSTANT_Utf8 constant pool items.
          */
         final static int UTF8 = 1;
@@ -455,6 +465,7 @@ public class BytecodeReadingParanamer implements Paranamer {
                     case IMETH:
                     case INT:
                     case FLOAT:
+                    case INVOKEDYN:
                     case NAME_TYPE:
                         size = 5;
                         break;
@@ -462,6 +473,9 @@ public class BytecodeReadingParanamer implements Paranamer {
                     case DOUBLE:
                         size = 9;
                         ++i;
+                        break;
+                    case MHANDLE:
+                        size = 4;
                         break;
                     case UTF8:
                         size = 3 + readUnsignedShort(index + 1);
@@ -613,7 +627,6 @@ public class BytecodeReadingParanamer implements Paranamer {
                 // inlined in original ASM source, now a method call
                 u = readMethod(classVisitor, c, u);
             }
-
         }
 
         private int readMethod(TypeCollector classVisitor, char[] c, int u) {


### PR DESCRIPTION
Fixing issue #17 adding constant pool tags: CONSTANT_InvokeDynamic and CONSTANT_MethodHandle.

I don't know how to test using `BytecodeReadingParanamerTestCase` class because we need to change compiler source and target to Java 8, that will break projects that uses prior versions of Java.

The code to test this code is:

```java
    public static class ClassWithLambdas {
    	private static Supplier<String> aMethod(String name) {
    		return () -> name;
    	}
    }
```

```java
    @Test
    // https://github.com/paul-hammant/paranamer/issues/17
    public void testMethodWithLambdaExpressions() throws Exception {
        BytecodeReadingParanamer paranamer = new BytecodeReadingParanamer();

        Method method = ClassWithLambdas.class.getDeclaredMethod("aMethod", String.class);
        String[] names = paranamer.lookupParameterNames(method);
        assertEquals("name", names[0]);
    }
```