### PR TITLE
Self closing tags not allowed for Javadoc in JDK8

### DIFF
--- a/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
@@ -44,7 +44,7 @@ import java.util.Map;
 /**
  * An ASM-based implementation of Paranamer. It relies on debug information compiled
  * with the "-g" javac option to retrieve parameter names.
- * <p/>
+ * <p>
  * Portions of this source file are a fork of ASM.
  *
  * @author Guilherme Silveira


### PR DESCRIPTION
If you try to run javadoc with JDK8 you get this error message 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadoc) on project paranamer: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - E:\checkout\paranamer-master\paranamer\src\java\com\thoughtworks\paranamer\BytecodeReadingParanamer.java:47: error: self-closing element not allowed
[ERROR] * <p/>
[ERROR] ^
```

For more details about this, see stackoverflow post : http://stackoverflow.com/questions/26049329/javadoc-in-jdk-8-invalid-self-closing-element-not-allowed