### PR TITLE
Use default method in Paranamer interface

### DIFF
--- a/paranamer/src/java/com/thoughtworks/paranamer/AdaptiveParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/AdaptiveParanamer.java
@@ -65,10 +65,6 @@ public class AdaptiveParanamer implements Paranamer {
         this.paranamers = paranamers;
     }
 
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
-    }
-
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
         for (int i = 0; i < paranamers.length; i++) {
             Paranamer paranamer = paranamers[i];

--- a/paranamer/src/java/com/thoughtworks/paranamer/AnnotationParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/AnnotationParanamer.java
@@ -30,12 +30,11 @@
 
 package com.thoughtworks.paranamer;
 
+import javax.inject.Named;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-
-import javax.inject.Named;
 
 /**
  * Implementation of Paranamer that uses @Named annotation of JSR 330.
@@ -57,10 +56,6 @@ public class AnnotationParanamer implements Paranamer {
 
     public AnnotationParanamer(Paranamer fallback) {
         this.fallback = fallback;
-    }
-
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {

--- a/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
@@ -65,10 +65,6 @@ public class BytecodeReadingParanamer implements Paranamer {
         }
     };
 
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
-    }
-
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
 
         Class<?>[] types = null;

--- a/paranamer/src/java/com/thoughtworks/paranamer/CachingParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/CachingParanamer.java
@@ -61,7 +61,7 @@ public class CachingParanamer implements Paranamer {
     private final Map<AccessibleObject,String[]> methodCache = makeMethodCache();
 
     protected Map<AccessibleObject, String[]> makeMethodCache() {
-        return Collections.synchronizedMap(new WeakHashMap<AccessibleObject, String[]>());
+        return Collections.synchronizedMap(new WeakHashMap<>());
     }
 
     /**
@@ -77,10 +77,6 @@ public class CachingParanamer implements Paranamer {
      */
     public CachingParanamer(Paranamer delegate) {
         this.delegate = delegate;
-    }
-
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
@@ -115,7 +111,7 @@ public class CachingParanamer implements Paranamer {
 
         @Override
         protected Map<AccessibleObject, String[]> makeMethodCache() {
-            return new ConcurrentHashMap<AccessibleObject,String[]>();
+            return new ConcurrentHashMap<>();
         }
     }
 

--- a/paranamer/src/java/com/thoughtworks/paranamer/DefaultParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/DefaultParanamer.java
@@ -30,11 +30,7 @@
 
 package com.thoughtworks.paranamer;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.*;
 
 /**
  * Default implementation of Paranamer reads from a post-compile added field called '__PARANAMER_DATA'
@@ -54,10 +50,6 @@ public class DefaultParanamer implements Paranamer {
         + "getParameterTypeName java.lang.Class cls\n";
 
     public DefaultParanamer() {
-    }
-
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {

--- a/paranamer/src/java/com/thoughtworks/paranamer/JavadocParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/JavadocParanamer.java
@@ -84,10 +84,6 @@ public class JavadocParanamer implements Paranamer {
         this.provider = new UrlJavadocProvider(url);
     }
 
-    public String[] lookupParameterNames(AccessibleObject accessible) {
-        return lookupParameterNames(accessible, true);
-    }
-
     public String[] lookupParameterNames(AccessibleObject accessible, boolean throwExceptionIfMissing) {
         if (!(accessible instanceof Member))
             throw new IllegalArgumentException(accessible.getClass().getCanonicalName());

--- a/paranamer/src/java/com/thoughtworks/paranamer/NullParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/NullParanamer.java
@@ -39,6 +39,7 @@ import java.lang.reflect.AccessibleObject;
  */
 public class NullParanamer implements Paranamer {
 
+    @Override
     public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
         return new String[0];
     }

--- a/paranamer/src/java/com/thoughtworks/paranamer/Paranamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/Paranamer.java
@@ -37,17 +37,20 @@ import java.lang.reflect.Method;
 
 /**
  * Paranamer allows lookups of methods and constructors by parameter names.
- * 
+ *
  * @author Paul Hammant
  * @author Mauro Talevi
  */
 public interface Paranamer {
 
-    static final String[] EMPTY_NAMES = new String[0];
+    String[] EMPTY_NAMES = new String[0];
 
 	/**
 	 * Lookup the parameter names of a given method.
-	 * 
+     *
+     * The default implementation calls
+     * <code>{@link #lookupParameterNames(AccessibleObject, boolean) lookupParameterNames(methodOrConstructor, true)}</code>.
+	 *
 	 * @param methodOrConstructor
 	 *            the {@link Method} or {@link Constructor} for which the parameter names
 	 *            are looked up.
@@ -60,7 +63,9 @@ public interface Paranamer {
 	 *             if reflection is not permitted on the containing {@link Class} of the
 	 *             parameter
 	 */
-	public String[] lookupParameterNames(AccessibleObject methodOrConstructor);
+	default String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
+        return lookupParameterNames(methodOrConstructor, true);
+    }
 
 	/**
 	 * Lookup the parameter names of a given method.
@@ -68,7 +73,7 @@ public interface Paranamer {
 	 * @param methodOrConstructor
 	 *            the {@link Method} or {@link Constructor} for which the parameter names
 	 *            are looked up.
-	 * @param throwExceptionIfMissing whether to throw an exception if no Paranamer data found (versus return null).
+	 * @param throwExceptionIfMissing whether to throw an exception if no Paranamer data found (versus return empty array).
      * @return A list of the parameter names.
 	 * @throws ParameterNamesNotFoundException
 	 *             if no parameter names were found.
@@ -78,7 +83,7 @@ public interface Paranamer {
 	 *             if reflection is not permitted on the containing {@link Class} of the
 	 *             parameter
 	 */
-	public String[] lookupParameterNames(AccessibleObject methodOrConstructor, boolean throwExceptionIfMissing);
+	String[] lookupParameterNames(AccessibleObject methodOrConstructor, boolean throwExceptionIfMissing);
 
 
 }

--- a/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
@@ -61,10 +61,6 @@ public class PositionalParanamer implements Paranamer {
         this.prefix = prefix;
     }
 
-    public String[] lookupParameterNames(AccessibleObject methodOrConstructor) {
-        return lookupParameterNames(methodOrConstructor, true);
-    }
-
     public String[] lookupParameterNames(AccessibleObject methodOrCtor,
             boolean throwExceptionIfMissing) {
         int count = count(methodOrCtor);


### PR DESCRIPTION
With one exception (`NullParanamer`), all implementations of the single-argument version of `Paranamer.lookupParameterNames` have the same implementation, delegating to the two argument version with `true` as the second argument.  This is also a sensible default for user-defined Paranamer instances.  Now that Paranamer requires a minimum of Java 8, it seems like a switch to a `default` method might be appropriate.  This PR implements this change.

Incidentally, not a big deal if you don't want to go this route.  Figured I'd throw it out there to see what your thoughts are on this approach.

That said, the fact that `NullParanamer` has different results for `Paranamer.lookupParameterNames(methodOrConstructor, true)` and `Paranamer.lookupParameterNames (methodOrConstructor)` does feel like a little bit of a code smell.

I have confirmed that this change does not break compilation of the build (`mvn clean install -DskipTests=true`).  I have not confirmed that unit tests pass, since unit tests appear to be broken in `master`.  I built on macOS 10.14.5 with Maven 3.8.2 & Java 8 using AdoptOpenJDK 1.8.0_282:

```
$ mvn clean install
[...]

[INFO] 
[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ paranamer-generator ---

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase
Tests run: 7, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.291 sec <<< FAILURE! - in com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase
testGenericClassGeneration(com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase)  Time elapsed: 0.106 sec  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...bo 
elephantArrays E[],java.lang.String th...> but was:<...bo 
elephantArrays E[[]],java.lang.String th...>
	at com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase.testGenericClassGeneration(OldQDoxParanamerTestCase.java:92)

testSimpleClassGeneration(com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase)  Time elapsed: 0.026 sec  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...nger 
longArray long[] longs 
setMap java....> but was:<...nger 
longArray long[[]] longs 
setMap java....>
	at com.thoughtworks.paranamer.generator.OldQDoxParanamerTestCase.testSimpleClassGeneration(OldQDoxParanamerTestCase.java:83)

Running com.thoughtworks.paranamer.generator.QDoxParanamerTestCase
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.016 sec <<< FAILURE! - in com.thoughtworks.paranamer.generator.QDoxParanamerTestCase
testFoo(com.thoughtworks.paranamer.generator.QDoxParanamerTestCase)  Time elapsed: 0.014 sec  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<...nger 
longArray long[] longs 
setMap java....> but was:<...nger 
longArray long[[]] longs 
setMap java....>
	at com.thoughtworks.paranamer.generator.QDoxParanamerTestCase.testFoo(QDoxParanamerTestCase.java:76)


Results :

Failed tests: 
  OldQDoxParanamerTestCase.testGenericClassGeneration:92 expected:<...bo 
elephantArrays E[],java.lang.String th...> but was:<...bo 
elephantArrays E[[]],java.lang.String th...>
  OldQDoxParanamerTestCase.testSimpleClassGeneration:83 expected:<...nger 
longArray long[] longs 
setMap java....> but was:<...nger 
longArray long[[]] longs 
setMap java....>
  QDoxParanamerTestCase.testFoo:76 expected:<...nger 
longArray long[] longs 
setMap java....> but was:<...nger 
longArray long[[]] longs 
setMap java....>

Tests run: 8, Failures: 3, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ParaNamer Parent 2.8.1-SNAPSHOT:
[INFO] 
[INFO] ParaNamer Parent ................................... SUCCESS [  0.214 s]
[INFO] ParaNamer Generator ................................ FAILURE [  1.894 s]
[INFO] ParaNamer Maven plugin ............................. SKIPPED
[INFO] ParaNamer Core ..................................... SKIPPED
[INFO] ParaNamer Ant ...................................... SKIPPED
[INFO] ParaNamer Integration Tests ........................ SKIPPED
[INFO] ParaNamer IT 011: can use maven plugin defaults .... SKIPPED
[INFO] ParaNamer Distribution ............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.693 s
[INFO] Finished at: 2021-08-28T21:43:54-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test (default-test) on project paranamer-generator: There are test failures.
[ERROR] 
[ERROR] Please refer to /path/to/paranamer/paranamer-generator/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :paranamer-generator
```
