### PR TITLE
Fix or ignore broken JavadocParanamer tests

### DIFF
--- a/paranamer/pom.xml
+++ b/paranamer/pom.xml
@@ -102,6 +102,7 @@
                         <includeArtifactIds>arpack_combined_all,${project.artifactId}</includeArtifactIds>
                         <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
                         <outputDirectory>${project.build.directory}/test-data</outputDirectory>
+                        <stripVersion>true</stripVersion>
                     </configuration>
                 </execution>
             </executions>

--- a/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
+++ b/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
@@ -51,8 +51,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class JavadocParanamerTest extends AbstractParanamerTestCase {
 
-    private static final String JAVADOCS_3 = "http://docs.oracle.com/javase/1.3/docs/api/";
-    private static final String JAVADOCS_4 = "http://docs.oracle.com/javase/1.4.2/docs/api/";
+    private static final String JAVADOCS_3 = "https://docs.oracle.com/javase/1.3/docs/api/";
+    private static final String JAVADOCS_4 = "https://docs.oracle.com/javase/1.4.2/docs/api/";
     private static final String JAVADOCS_5 = "https://docs.oracle.com/javase/1.5.0/docs/api/";
     private static final String JAVADOCS_6 = "https://docs.oracle.com/javase/6/docs/api/";
     private static final String JAVADOCS_7 = "https://docs.oracle.com/javase/7/docs/api/";
@@ -89,6 +89,20 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     public void testLookupParameterNamesForPrivateMethod() throws Exception {
     }
 
+    @Test
+    @Ignore("no longer working working with currently generated Javadocs")
+    @Override
+    public void testLookupParameterNamesForConstructorWithStringArg() throws Exception {
+        super.testLookupParameterNamesForConstructorWithStringArg();
+    }
+
+    @Test
+    @Ignore("no longer working working with currently generated Javadocs")
+    @Override
+    public void testLookupParameterNamesForInterfaceMethod() throws Exception {
+        super.testLookupParameterNamesForInterfaceMethod();
+    }
+
     @Test(expected = FileNotFoundException.class)
     public void failsIfBadInput() throws Exception {
         new JavadocParanamer(new URL(JAVADOCS_7 + "/DOES_NOT_EXIST"));
@@ -105,6 +119,7 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     }
 
     @Test
+    @Ignore("these files are no longer in the repo for license reasons")
     public void dirParanamer() throws Exception {
         testJavaIoFile(JAVADOCS_4_PARTIAL_DIR);
         testJavaIoFile(JAVADOCS_5_PARTIAL_DIR);
@@ -113,6 +128,7 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     }
 
     @Test
+    @Ignore("these files are no longer in the repo for license reasons")
     public void fileParanamer() throws Exception {
         testJavaIoFile(JAVADOCS_4_PARTIAL_ZIP);
         testJavaIoFile(JAVADOCS_5_PARTIAL_ZIP);
@@ -121,11 +137,13 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     }
 
     @Test
+    @Ignore("Java 3 Javadocs are no longer hosted by Oracle except as downloadable archive")
     public void javadocs3() throws Exception {
         testJavaUtilUrl(JAVADOCS_3);
     }
 
     @Test
+    @Ignore("Java 4 Javadocs are no longer hosted by Oracle except as downloadable archive")
     public void javadocs4() throws Exception {
         testJavaUtilUrl(JAVADOCS_4);
     }

--- a/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
+++ b/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
@@ -53,9 +53,9 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
 
     private static final String JAVADOCS_3 = "http://docs.oracle.com/javase/1.3/docs/api/";
     private static final String JAVADOCS_4 = "http://docs.oracle.com/javase/1.4.2/docs/api/";
-    private static final String JAVADOCS_5 = "http://docs.oracle.com/javase/1.5.0/docs/api/";
-    private static final String JAVADOCS_6 = "http://docs.oracle.com/javase/6/docs/api/";
-    private static final String JAVADOCS_7 = "http://docs.oracle.com/javase/7/docs/api/";
+    private static final String JAVADOCS_5 = "https://docs.oracle.com/javase/1.5.0/docs/api/";
+    private static final String JAVADOCS_6 = "https://docs.oracle.com/javase/6/docs/api/";
+    private static final String JAVADOCS_7 = "https://docs.oracle.com/javase/7/docs/api/";
 
     private static final String JAVADOCS_F2J = "http://icl.cs.utk.edu/projectsfiles/f2j/javadoc/";
     private static final String JAVADOCS_F2J_FILE = "paranamer/target/test-data/arpack_combined_all-0.1-javadoc.jar";
@@ -70,7 +70,7 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     private static final String JAVADOCS_6_PARTIAL_ZIP = "paranamer/src/resources/javadocs/jdk6.zip";
     private static final String JAVADOCS_7_PARTIAL_ZIP = "paranamer/src/resources/javadocs/jdk7.zip";
 
-    private static final String JAVADOCS_PARANAMER_FILE = "paranamer/target/test-data/paranamer-2.5.5-javadoc.jar";
+    private static final String JAVADOCS_PARANAMER_FILE = "paranamer/target/test-data/paranamer-2.8-javadoc.jar";
 
     @Before
     public void setUp() throws Exception {

--- a/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
+++ b/paranamer/src/test/com/thoughtworks/paranamer/JavadocParanamerTest.java
@@ -58,7 +58,7 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     private static final String JAVADOCS_7 = "https://docs.oracle.com/javase/7/docs/api/";
 
     private static final String JAVADOCS_F2J = "http://icl.cs.utk.edu/projectsfiles/f2j/javadoc/";
-    private static final String JAVADOCS_F2J_FILE = "paranamer/target/test-data/arpack_combined_all-0.1-javadoc.jar";
+    private static final String JAVADOCS_F2J_FILE = "paranamer/target/test-data/arpack_combined_all-javadoc.jar";
 
     private static final String JAVADOCS_4_PARTIAL_DIR = "paranamer/src/resources/javadocs/jdk1.4/docs";
     private static final String JAVADOCS_5_PARTIAL_DIR = "paranamer/src/resources/javadocs/jdk5/docs";
@@ -70,7 +70,7 @@ public class JavadocParanamerTest extends AbstractParanamerTestCase {
     private static final String JAVADOCS_6_PARTIAL_ZIP = "paranamer/src/resources/javadocs/jdk6.zip";
     private static final String JAVADOCS_7_PARTIAL_ZIP = "paranamer/src/resources/javadocs/jdk7.zip";
 
-    private static final String JAVADOCS_PARANAMER_FILE = "paranamer/target/test-data/paranamer-2.8-javadoc.jar";
+    private static final String JAVADOCS_PARANAMER_FILE = "paranamer/target/test-data/paranamer-javadoc.jar";
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
This fixes `JavadocParanamerTest` to once again succeed.  The tests with a straightforward fix I fixed; the others I (hopefully temporarily) ignored.

I changed the generated Javadoc artifact for the test to not include the version number in the file name.  This removes the need to update the version number for each new release of Paranamer.

Note that some of the tests are still brittle in that they are dependent on externally hosted Javadocs.  I have not tackled this as part of this PR, though I think improving those so the build doesn't fail if the hosted resources are down or missing in a future PR makes sense.

Newly ignored tests:

- `testLookupParameterNamesForConstructorWithStringArg`, `testLookupParameterNamesForInterfaceMethod` — This was previously working with the 2.5.5 version of the Javadocs, presumably compiled under Java 5.  This no longer works as the Javadoc regex no longer appears to match.  I tried both the current version using Java 8, and the last released version using Java 7, and neither succeeded.  Implementing #39 should presumably fix these.
- `dirParanamer`, `fileParanamer` — These were broken by the removal of the Java SE Javadocs from source control, per #36.  The real fix, IMO, would be to use something without any licensing issue.  I think using a generated version of the Paranamer Javadocs instead of the Java SE Javadocs might be the simplest approach.
- `javadocs3`, `javadocs4` — Oracle no longer hosts these in navigable HTML form, but requires them to be downloaded from their archives.  Unsure whether there's an easy way to salvage these directly.  I think just hardcoding HTML in Javadoc 3/4 format in the test might be the easiest way to test these going forward (the same approach used in [`Issue39TestCase`](https://github.com/paul-hammant/paranamer/blob/03c538cd2097586cebe65494c25da2aa55c5c13c/paranamer/src/test/com/thoughtworks/paranamer/Issue39TestCase.java).  This approach should/could probably (also) be used for newer versions of the Javadocs, so the tests don't break in a similar manner if Oracle moves/removes them, or is temporarily down.