### PR TITLE
Refactor to use Executable

### DIFF
--- a/paranamer/src/java/com/thoughtworks/paranamer/AnnotationParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/AnnotationParanamer.java
@@ -30,12 +30,11 @@
 
 package com.thoughtworks.paranamer;
 
+import javax.inject.Named;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
-import javax.inject.Named;
+import java.lang.reflect.Executable;
 
 /**
  * Implementation of Paranamer that uses @Named annotation of JSR 330.
@@ -64,24 +63,12 @@ public class AnnotationParanamer implements Paranamer {
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
-        // Oh for some commonality between Constructor and Method !!
-        Class<?>[] types = null;
-        Class<?> declaringClass = null;
-        String name = null;
-        Annotation[][] anns = null;
-        if (methodOrCtor instanceof Method) {
-            Method method = (Method) methodOrCtor;
-            types = method.getParameterTypes();
-            name = method.getName();
-            declaringClass = method.getDeclaringClass();
-            anns = method.getParameterAnnotations();
-        } else {
-            Constructor<?> constructor = (Constructor<?>) methodOrCtor;
-            types = constructor.getParameterTypes();
-            declaringClass = constructor.getDeclaringClass();
-            name = "<init>";
-            anns = constructor.getParameterAnnotations();
-        }
+        Executable executable = (Executable) methodOrCtor;
+
+        Class<?>[] types = executable.getParameterTypes();
+        Class<?> declaringClass = executable.getDeclaringClass();
+        String name = executable instanceof Constructor ? "<init>" : executable.getName();
+        Annotation[][] anns = executable.getParameterAnnotations();
 
         if (types.length == 0) {
             return EMPTY_NAMES;

--- a/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/BytecodeReadingParanamer.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,21 +70,12 @@ public class BytecodeReadingParanamer implements Paranamer {
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
+        Executable executable = (Executable) methodOrCtor;
 
-        Class<?>[] types = null;
-        Class<?> declaringClass = null;
-        String name = null;
-        if (methodOrCtor instanceof Method) {
-            Method method = (Method) methodOrCtor;
-            types = method.getParameterTypes();
-            name = method.getName();
-            declaringClass = method.getDeclaringClass();
-        } else {
-            Constructor<?> constructor = (Constructor<?>) methodOrCtor;
-            types = constructor.getParameterTypes();
-            declaringClass = constructor.getDeclaringClass();
-            name = "<init>";
-        }
+        Class<?>[] types = executable.getParameterTypes();
+        Class<?> declaringClass = executable.getDeclaringClass();
+        String name = executable instanceof Constructor ? "<init>" : executable.getName();
+
 
         if (types.length == 0) {
             return EMPTY_NAMES;

--- a/paranamer/src/java/com/thoughtworks/paranamer/DefaultParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/DefaultParanamer.java
@@ -30,11 +30,7 @@
 
 package com.thoughtworks.paranamer;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.*;
 
 /**
  * Default implementation of Paranamer reads from a post-compile added field called '__PARANAMER_DATA'
@@ -61,21 +57,11 @@ public class DefaultParanamer implements Paranamer {
     }
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor, boolean throwExceptionIfMissing) {
-        // Oh for some commonality between Constructor and Method !!
-        Class<?>[] types = null;
-        Class<?> declaringClass = null;
-        String name = null;
-        if (methodOrCtor instanceof Method) {
-            Method method = (Method) methodOrCtor;
-            types = method.getParameterTypes();
-            name = method.getName();
-            declaringClass = method.getDeclaringClass();
-        } else {
-            Constructor<?> constructor = (Constructor<?>) methodOrCtor;
-            types = constructor.getParameterTypes();
-            declaringClass = constructor.getDeclaringClass();
-            name = "<init>";
-        }
+        Executable executable = (Executable) methodOrCtor;
+
+        Class<?>[] types = executable.getParameterTypes();
+        Class<?> declaringClass = executable.getDeclaringClass();
+        String name = executable instanceof Constructor ? "<init>" : executable.getName();
 
         if (types.length == 0) {
             return EMPTY_NAMES;

--- a/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
+++ b/paranamer/src/java/com/thoughtworks/paranamer/PositionalParanamer.java
@@ -30,8 +30,7 @@
 package com.thoughtworks.paranamer;
 
 import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
+import java.lang.reflect.Executable;
 
 /**
  * Paranamer that works on basis of the parameter position and can be used as
@@ -67,21 +66,11 @@ public class PositionalParanamer implements Paranamer {
 
     public String[] lookupParameterNames(AccessibleObject methodOrCtor,
             boolean throwExceptionIfMissing) {
-        int count = count(methodOrCtor);
+        int count = ((Executable) methodOrCtor).getParameterCount();
         String[] result = new String[count];
         for (int i = 0; i < result.length; i++) {
             result[i] = prefix + i;
         }
         return result;
     }
-    
-    private int count(AccessibleObject methodOrCtor) {
-        if (methodOrCtor instanceof Method) {
-            Method method = (Method) methodOrCtor;
-            return method.getParameterTypes().length;
-        }
-        Constructor<?> constructor = (Constructor<?>) methodOrCtor;
-        return constructor.getParameterTypes().length;
-    }
-
 }


### PR DESCRIPTION
Java 8 added the [`Executable`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Executable.html) type implemented by `Method` and `Constructor`.  Now that the project has been updated to Java 8, this type can now be used.  This PR refactors the implementation to use this type where it results in a cleaner result.

I did not update the `Paranamer` interface to use the `Executable` type (rather than [`AccessibleObject`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/AccessibleObject.html)).  While I imagine most usages currently in the wild wouldn't require rewriting (unless they're implementing `Paranamer` or passing in a `AccessibleObject` rather than a `Method` or `Constructor`), I'm not sure changing the main interface in a binary incompatible way makes sense for a library that's mostly in maintenance mode.  That said, if you feel that sort of change is warranted along with the switch to Java 8 as a 3.0 release or something, it would certainly be a straightforward change.