### PR TITLE
#34 upgrade to ASM 9.2

### DIFF
--- a/paranamer-generator/pom.xml
+++ b/paranamer-generator/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>5.1</version>
+      <version>9.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
In order to support java bytecode newer than Java 1.8, we need to upgrade the ASM library. I've picked 9.2 as it's the newest one at the time of writing.

https://asm.ow2.io/versions.html